### PR TITLE
Upgrade jersey from 2.31 to 2.35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <!-- keep jetty.version in sync with security-parent/management-apps -->
         <jetty.version>9.4.43.v20210629</jetty.version>
         <jackson.version>2.11.1</jackson.version>
-        <jersey.version>2.31</jersey.version>
+        <jersey.version>2.35</jersey.version>
 
         <guava.version>30.1.1-jre</guava.version>
         <groovy.version>2.5.8</groovy.version>


### PR DESCRIPTION
* Includes fix for CVE-2021-28168