### PR TITLE
Tab 8281 4.3.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,13 +17,13 @@
     <properties>
         <!-- keep jetty.version in sync with security-parent/management-apps -->
         <jetty.version>9.4.48.v20220622</jetty.version>
-        <jackson.version>2.13.4</jackson.version>
-        <jackson-databind.version>2.13.4.2</jackson-databind.version>
+        <jackson.version>2.14.2</jackson.version>
+        <jackson-databind.version>2.14.2</jackson-databind.version>
         <jersey.version>2.36</jersey.version>
 
         <guava.version>31.1-jre</guava.version>
         <groovy.version>3.0.12</groovy.version>
-        <shiro.version>1.10.0</shiro.version>
+        <shiro.version>1.11.0</shiro.version>
         <csrfguard.version>4.2.0</csrfguard.version>
 
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
Upgrade shiro(1.11.0) and jackson version(2.14.2) for 3rd party vulnerability - #TAB-8281