### PR TITLE
TAB-8330 Vulnerable 3rd party component json-smart used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,12 @@
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
-                <version>2.7.0</version>
+                <version>2.8.0</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.4.10</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.shiro</groupId>


### PR DESCRIPTION
Fixed by upgrading json-path 2.7.0 to 2.8.0 and json-smart 2.4.7 to 2.4.10.
Fixed by adding json-smart in management-cli-oss maven build and adding it to 3rd party bom.