### PR TITLE
Upgrade jetty, jackson, guava, commons-io, rest-assured, bytebuddy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,12 @@
 
     <properties>
         <!-- keep jetty.version in sync with security-parent/management-apps -->
-        <jetty.version>10.0.16</jetty.version>
-        <jackson.version>2.15.2</jackson.version>
+        <jetty.version>10.0.17</jetty.version>
+        <jackson.version>2.15.3</jackson.version>
         <jersey.version>2.40</jersey.version>
 
-        <guava.version>32.1.2-jre</guava.version>
-        <groovy.version>4.0.13</groovy.version>
+        <guava.version>32.1.3-jre</guava.version>
+        <groovy.version>4.0.15</groovy.version>
         <shiro.version>1.12.0</shiro.version>
         <csrfguard.version>4.3.0</csrfguard.version>
 
@@ -35,7 +35,7 @@
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.13.0</commons-lang3.version>
         <commons-cli.version>1.5.0</commons-cli.version>
-        <commons-io.version>2.13.0</commons-io.version>
+        <commons-io.version>2.14.0</commons-io.version>
         <commons-logging.version>1.2</commons-logging.version>
         <commons-httpclient.version>3.1</commons-httpclient.version>
         <jaxb-runtime.version>2.3.8</jaxb-runtime.version>
@@ -46,8 +46,8 @@
         <derby.version>10.15.2.0</derby.version>
         <apacheds.version>2.0.0.AM25</apacheds.version>
         <byteman.version>4.0.21</byteman.version>
-        <rest-assured.version>5.3.1</rest-assured.version>
-        <bytebuddy.version>1.14.5</bytebuddy.version>
+        <rest-assured.version>5.3.2</rest-assured.version>
+        <bytebuddy.version>1.14.9</bytebuddy.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Upgrade jetty to 10.0.17, jackson to 2.15.3, guava to 32.1.3-jre, commons-io to 2.14.0, rest-assured to 5.3.2, bytebuddy to 1.14.9
Upgrade jetty, jackson, guava, commons-io, rest-assured, bytebuddy