### PR TITLE
Artifactory conversion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <groupId>org.terracotta.forge</groupId>
         <artifactId>forge-parent</artifactId>
-        <version>8.1</version>
+        <version>9.0</version>
     </parent>
 
     <groupId>org.terracotta</groupId>
@@ -30,6 +30,8 @@ limitations under the License.
     <packaging>pom</packaging>
 
     <properties>
+        <artifactory-build-name>thirdparty-bom</artifactory-build-name>
+
         <!-- keep jetty.version in sync with security-parent/management-apps -->
         <jetty.version>12.0.16</jetty.version>
         <jackson.version>2.18.2</jackson.version>
@@ -40,7 +42,7 @@ limitations under the License.
         <shiro.version>1.13.0</shiro.version>
         <csrfguard.version>4.4.0-jakarta</csrfguard.version>
         <slf4j.version>1.7.36</slf4j.version>
-	<logback.version>1.2.13</logback.version>
+        <logback.version>1.2.13</logback.version>
         <junit.version>4.13.2</junit.version>
         <commons-beanutils.version>1.10.0</commons-beanutils.version>
         <hamcrest.version>3.0</hamcrest.version>


### PR DESCRIPTION
This PR and others like it will break compatibility with SAG infra, moving deploy/build coordinates to IBM

Note that parent pom is only available in artifactory at the moment.  ~~Eventually it'll be on repo.terracotta.org~~  Manually uploaded.   Which means that all the downstream OSS projects will fail to build PRs unless I manually upload all the artifacts to repo.

**Update**: all artifacts are automatically available on repo/snapshots now.