### PR TITLE
TAB-10003: upgrade Bounce Castle (brought in by Shiro) for CVE.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@ limitations under the License.
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency> <!-- TAB-10003: CVE-2026-0636 -->
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.84</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.xmlbeans</groupId>
                 <artifactId>xmlbeans</artifactId>


### PR DESCRIPTION
(cherry picked from commit f583aa46d981a36ea3bed9517efad14bffd82cf0)