### PR TITLE
[TAB-10049-release-4.5.0]: Upgrade shiro to 2.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@ limitations under the License.
 
         <guava.version>33.5.0-jre</guava.version>
         <groovy.version>4.0.30</groovy.version>
-        <shiro.version>2.2.0</shiro.version>
+        <shiro.version>2.2.1</shiro.version>
         <csrfguard.version>4.4.0-jakarta</csrfguard.version>
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.34</logback.version>


### PR DESCRIPTION
(cherry picked from commit 3a10407a0b114fa402abb641aada832246bf5aac)