### PR TITLE
[TAB-10099] Upgrade Jetty due to CVE-2026-6790, CVE-2026-8384

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
         <artifactory-build-name>thirdparty-bom</artifactory-build-name>
 
         <!-- keep jetty.version in sync with security-parent/management-apps -->
-        <jetty.version>12.0.34</jetty.version>
+        <jetty.version>12.0.37</jetty.version>
         <jackson.version>2.21.5</jackson.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <jersey.version>3.1.11</jersey.version>
@@ -42,7 +42,7 @@ limitations under the License.
         <groovy.version>4.0.30</groovy.version>
         <shiro.version>2.2.1</shiro.version>
         <csrfguard.version>4.4.0-jakarta</csrfguard.version>
-        <slf4j.version>2.0.17</slf4j.version>
+        <slf4j.version>2.0.18</slf4j.version>
         <logback.version>1.5.34</logback.version>
         <junit.version>4.13.2</junit.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>


### PR DESCRIPTION
Update jetty to 12.0.37 and slf4j to 2.0.18